### PR TITLE
Update custom-directive.md

### DIFF
--- a/src/guide/custom-directive.md
+++ b/src/guide/custom-directive.md
@@ -82,7 +82,7 @@ directives: {
   - **expression**: 绑定值的字符串形式。 例如 `v-my-directive="1 + 1"` ， expression 的值是 `"1 + 1"`。
   - **arg**: 传给指令的参数。例如 `v-my-directive:foo`， arg 的值是 `"foo"`。
   - **modifiers**: 一个包含修饰符的对象。 例如： `v-my-directive.foo.bar`, 修饰符对象 modifiers 的值是 `{ foo: true, bar: true }`。
-- **vnode**: Vue 编译生成的虚拟节点，查阅 [VNode API](/api/#VNode-Interface) 了解更多详情。
+- **vnode**: Vue 编译生成的虚拟节点，查阅 [VNode API](/api/#VNode接口) 了解更多详情。
 - **oldVnode**: 上一个虚拟节点，仅在 `update` 和 `componentUpdated` 钩子中可用。
 
 <p class="tip">除了 `el` 之外，其它参数都应该是只读的，尽量不要修改他们。如果需要在钩子之间共享数据，建议通过元素的 [dataset](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset) 来进行。</p>


### PR DESCRIPTION
“教程”-“自定义指令”-“勾子函数参数”里面的“查阅VNode API”的url的hash不对，还是英文原站的hash值，所以换成中文hash。